### PR TITLE
Add CBC Construction website with service pages

### DIFF
--- a/flooring.html
+++ b/flooring.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Flooring Services | CBC Construction Inc.</title>
+  <meta name="description" content="Quality flooring installation and repair by CBC Construction Inc. in Danvers, MA. Call 123-456-7879 today." />
+  <link rel="canonical" href="https://cbcconstruction.biz/flooring.html" />
+  <link rel="stylesheet" href="style.css" />
+  <script defer src="script.js"></script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Service",
+    "serviceType": "Flooring",
+    "provider": {
+      "@type": "LocalBusiness",
+      "name": "CBC Construction Inc.",
+      "url": "https://cbcconstruction.biz/",
+      "telephone": "123-456-7879",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "61 Elm St.",
+        "addressLocality": "Danvers",
+        "addressRegion": "MA",
+        "postalCode": "01923",
+        "addressCountry": "US"
+      }
+    }
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <div class="container">
+      <h1><a href="index.html">CBC Construction Inc.</a></h1>
+      <nav>
+        <ul>
+          <li><a href="index.html">Home</a></li>
+          <li><a href="painting.html">Painting</a></li>
+          <li><a href="remodeling.html">Remodeling</a></li>
+          <li><a href="flooring.html" aria-current="page">Flooring</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+  <main>
+    <section class="hero">
+      <h2>Flooring Services</h2>
+      <p>Installation and repair of hardwood, tile, laminate, and more.</p>
+    </section>
+    <section class="content">
+      <h3>Durable &amp; Stylish Floors</h3>
+      <p>We offer expert flooring solutions tailored to your space and lifestyle.</p>
+      <p>Explore our <a href="painting.html">Painting</a> and <a href="remodeling.html">Remodeling</a> services for complete renovations.</p>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; <span id="year"></span> CBC Construction Inc. | 61 Elm St., Danvers, MA 01923 | <a href="tel:1234567879">123-456-7879</a></p>
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CBC Construction Inc. | Home</title>
+  <meta name="description" content="CBC Construction Inc. provides painting, remodeling, and flooring services in Danvers, MA. Call 123-456-7879 for a free estimate." />
+  <link rel="canonical" href="https://cbcconstruction.biz/" />
+  <link rel="stylesheet" href="style.css" />
+  <script defer src="script.js"></script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "LocalBusiness",
+    "name": "CBC Construction Inc.",
+    "url": "https://cbcconstruction.biz/",
+    "telephone": "123-456-7879",
+    "address": {
+      "@type": "PostalAddress",
+      "streetAddress": "61 Elm St.",
+      "addressLocality": "Danvers",
+      "addressRegion": "MA",
+      "postalCode": "01923",
+      "addressCountry": "US"
+    }
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <div class="container">
+      <h1><a href="index.html">CBC Construction Inc.</a></h1>
+      <nav>
+        <ul>
+          <li><a href="index.html">Home</a></li>
+          <li><a href="painting.html">Painting</a></li>
+          <li><a href="remodeling.html">Remodeling</a></li>
+          <li><a href="flooring.html">Flooring</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+  <main>
+    <section class="hero">
+      <h2>Your Trusted Construction Partner</h2>
+      <p>Serving Danvers, MA and surrounding areas.</p>
+      <a class="cta" href="tel:1234567879">Call 123-456-7879</a>
+    </section>
+    <section class="services">
+      <h2>Our Services</h2>
+      <div class="service-list">
+        <article>
+          <h3><a href="painting.html">Painting</a></h3>
+          <p>High-quality interior and exterior painting.</p>
+        </article>
+        <article>
+          <h3><a href="remodeling.html">Remodeling</a></h3>
+          <p>Transform your space with custom remodeling.</p>
+        </article>
+        <article>
+          <h3><a href="flooring.html">Flooring</a></h3>
+          <p>Professional installation of hardwood, tile, and more.</p>
+        </article>
+      </div>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; <span id="year"></span> CBC Construction Inc. | 61 Elm St., Danvers, MA 01923 | <a href="tel:1234567879">123-456-7879</a></p>
+  </footer>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cbc-construction-website",
+  "version": "1.0.0",
+  "description": "CBC Construction Inc. multi-page website",
+  "private": true,
+  "scripts": {
+    "test": "echo \"No tests specified\""
+  },
+  "keywords": ["cbc", "construction", "website"],
+  "author": "",
+  "license": "MIT"
+}

--- a/painting.html
+++ b/painting.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Painting Services | CBC Construction Inc.</title>
+  <meta name="description" content="Professional interior and exterior painting services by CBC Construction Inc. in Danvers, MA. Contact us at 123-456-7879." />
+  <link rel="canonical" href="https://cbcconstruction.biz/painting.html" />
+  <link rel="stylesheet" href="style.css" />
+  <script defer src="script.js"></script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Service",
+    "serviceType": "Painting",
+    "provider": {
+      "@type": "LocalBusiness",
+      "name": "CBC Construction Inc.",
+      "url": "https://cbcconstruction.biz/",
+      "telephone": "123-456-7879",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "61 Elm St.",
+        "addressLocality": "Danvers",
+        "addressRegion": "MA",
+        "postalCode": "01923",
+        "addressCountry": "US"
+      }
+    }
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <div class="container">
+      <h1><a href="index.html">CBC Construction Inc.</a></h1>
+      <nav>
+        <ul>
+          <li><a href="index.html">Home</a></li>
+          <li><a href="painting.html" aria-current="page">Painting</a></li>
+          <li><a href="remodeling.html">Remodeling</a></li>
+          <li><a href="flooring.html">Flooring</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+  <main>
+    <section class="hero">
+      <h2>Painting Services</h2>
+      <p>Fresh coats for interiors and exteriors that last.</p>
+    </section>
+    <section class="content">
+      <h3>Interior &amp; Exterior Painting</h3>
+      <p>Our experienced painters deliver clean, precise work using premium materials. We handle everything from prep to final touch-ups.</p>
+      <p>Looking for other services? Explore our <a href="remodeling.html">Remodeling</a> and <a href="flooring.html">Flooring</a> solutions.</p>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; <span id="year"></span> CBC Construction Inc. | 61 Elm St., Danvers, MA 01923 | <a href="tel:1234567879">123-456-7879</a></p>
+  </footer>
+</body>
+</html>

--- a/remodeling.html
+++ b/remodeling.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Remodeling Services | CBC Construction Inc.</title>
+  <meta name="description" content="CBC Construction Inc. provides expert remodeling services in Danvers, MA. Call 123-456-7879 to discuss your project." />
+  <link rel="canonical" href="https://cbcconstruction.biz/remodeling.html" />
+  <link rel="stylesheet" href="style.css" />
+  <script defer src="script.js"></script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Service",
+    "serviceType": "Remodeling",
+    "provider": {
+      "@type": "LocalBusiness",
+      "name": "CBC Construction Inc.",
+      "url": "https://cbcconstruction.biz/",
+      "telephone": "123-456-7879",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "61 Elm St.",
+        "addressLocality": "Danvers",
+        "addressRegion": "MA",
+        "postalCode": "01923",
+        "addressCountry": "US"
+      }
+    }
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <div class="container">
+      <h1><a href="index.html">CBC Construction Inc.</a></h1>
+      <nav>
+        <ul>
+          <li><a href="index.html">Home</a></li>
+          <li><a href="painting.html">Painting</a></li>
+          <li><a href="remodeling.html" aria-current="page">Remodeling</a></li>
+          <li><a href="flooring.html">Flooring</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+  <main>
+    <section class="hero">
+      <h2>Remodeling Services</h2>
+      <p>Customized renovations to fit your style and budget.</p>
+    </section>
+    <section class="content">
+      <h3>Kitchen, Bath &amp; More</h3>
+      <p>From kitchens to basements, our team handles every phase of your remodel with precision and care.</p>
+      <p>Need a new look? Consider our <a href="painting.html">Painting</a> or <a href="flooring.html">Flooring</a> services.</p>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; <span id="year"></span> CBC Construction Inc. | 61 Elm St., Danvers, MA 01923 | <a href="tel:1234567879">123-456-7879</a></p>
+  </footer>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,7 @@
+// Simple script to update the year and improve accessibility
+window.addEventListener('DOMContentLoaded', () => {
+  const yearEl = document.getElementById('year');
+  if (yearEl) {
+    yearEl.textContent = new Date().getFullYear();
+  }
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,14 @@
+/* Basic reset */
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body { font-family: Arial, sans-serif; line-height: 1.6; color: #333; }
+.container { max-width: 1200px; margin: 0 auto; padding: 0 1rem; }
+header { background: #222; color: #fff; }
+header h1 a { color: #fff; text-decoration: none; }
+nav ul { list-style: none; display: flex; gap: 1rem; }
+nav a { color: #fff; text-decoration: none; }
+nav a[aria-current="page"] { border-bottom: 2px solid #fff; }
+.hero { background: linear-gradient(135deg, #555, #222); padding: 4rem 1rem; color: #fff; text-align: center; }
+.cta { display: inline-block; margin-top: 1rem; padding: 0.5rem 1rem; background: #ff9900; color: #000; text-decoration: none; }
+.services .service-list { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); }
+footer { text-align: center; background: #f4f4f4; padding: 1rem; margin-top: 2rem; }
+@media (max-width: 600px) { nav ul { flex-direction: column; } }


### PR DESCRIPTION
## Summary
- Add multi-page CBC Construction Inc. website with home and service pages for Painting, Remodeling, and Flooring
- Implement responsive design, navigation, and schema markup with canonical links and metadata for SEO
- Include simple JavaScript for dynamic footer year and modular CSS styling

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b9cec7e1548332aa1afff88269eb59